### PR TITLE
Syntax highlighting improvements

### DIFF
--- a/templates/syntax/terraform.vim
+++ b/templates/syntax/terraform.vim
@@ -19,13 +19,13 @@ syn cluster terraCommentGroup contains=terraTodo
 syn region  terraComment      start="/\*" end="\*/" contains=@terraCommentGroup,@Spell
 syn region  terraComment      start="#" end="$" contains=@terraCommentGroup,@Spell
 
-syn match  terraResource        /resource/ nextgroup=terraResourceTypeStr skipwhite
+syn match  terraResource        /\<resource\>/ nextgroup=terraResourceTypeStr skipwhite
 syn region terraResourceTypeStr start=/"/ end=/"/ contains=terraResourceTypeBI
                               \ nextgroup=terraResourceName skipwhite
 syn region terraResourceName    start=/"/ end=/"/
                               \ nextgroup=terraResourceBlock skipwhite
 """ provider
-syn match  terraProvider      /provider/ nextgroup=terraProviderName skipwhite
+syn match  terraProvider      /\<provider\>/ nextgroup=terraProviderName skipwhite
 syn region terraProviderName  start=/"/ end=/"/ nextgroup=terraProviderBlock skipwhite
 
 """ misc.

--- a/templates/syntax/terraform.vim
+++ b/templates/syntax/terraform.vim
@@ -35,6 +35,7 @@ syn match	terraBraces	       "[{}\[\]]"
 
 syn region terraValueString  start=/"/    end=/"/    contains=terraStringInterp
 syn region terraStringInterp matchgroup=terraBrackets start=/\${/  end=/}/ contained
+                           \ contains=terraStringInterp
 
 hi def link terraComment           Comment
 hi def link terraTodo              Todo


### PR DESCRIPTION
Two small but useful syntax highlighting improvements:

* Add word boundaries to the "resource" and "provider" keywords so they're only highlighted when they appear on their own. This lets you have, for example, a resource named "foo_provider" without having the second half of the name highlighted.
* Allow string interpolation to be nested. It's valid Terraform syntax to write something like `"${file(${var.my_file})}"` but currently the string interpolation highlighting is terminated at the first "}" character, causing nested interpolation to incorrectly highlight the rest of the file.