### PR TITLE
Allow escaped quotes in strings

### DIFF
--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -34,7 +34,7 @@ syn match terraValueDec      "\<[0-9]\+\([kKmMgG]b\?\)\?\>"
 syn match terraValueHexaDec  "\<0x[0-9a-f]\+\([kKmMgG]b\?\)\?\>"
 syn match	terraBraces	       "[{}\[\]]"
 
-syn region terraValueString  start=/"/    end=/"/    contains=terraStringInterp
+syn region terraValueString  start=/\\\@<!"/    end=/\\\@<!"/    contains=terraStringInterp
 syn region terraStringInterp matchgroup=terraBrackets start=/\${/  end=/}/ contained
                            \ contains=terraStringInterp
 

--- a/templates/syntax/terraform.vim
+++ b/templates/syntax/terraform.vim
@@ -33,7 +33,7 @@ syn match terraValueDec      "\<[0-9]\+\([kKmMgG]b\?\)\?\>"
 syn match terraValueHexaDec  "\<0x[0-9a-f]\+\([kKmMgG]b\?\)\?\>"
 syn match	terraBraces	       "[{}\[\]]"
 
-syn region terraValueString  start=/"/    end=/"/    contains=terraStringInterp
+syn region terraValueString  start=/\\\@<!"/    end=/\\\@<!"/    contains=terraStringInterp
 syn region terraStringInterp matchgroup=terraBrackets start=/\${/  end=/}/ contained
                            \ contains=terraStringInterp
 


### PR DESCRIPTION
Not much more to say about this one! Highlights strings of the form `"hello \"there\""` properly, where before the second `"` would have closed the string, by the syntax's estimation.